### PR TITLE
Optimize floating particle setup

### DIFF
--- a/RESUME
+++ b/RESUME
@@ -176,28 +176,41 @@ const LoadingSpinner = () => (
 );
 
 // Floating Particles Component
-const FloatingParticles = ({ count = 15 }) => (
-  <div className="absolute inset-0 overflow-hidden pointer-events-none">
-    {Array.from({ length: count }).map((_, i) => (
-      <div
-        key={i}
-        className="absolute w-2 h-2 bg-gradient-to-br from-blue-400/30 to-purple-400/30 rounded-full"
-        style={{
-          left: `${Math.random() * 100}%`,
-          top: `${Math.random() * 100}%`,
-          animation: `float ${3 + Math.random() * 4}s ease-in-out infinite`,
-          animationDelay: `${Math.random() * 2}s`
-        }}
-      />
-    ))}
-    <style jsx>{`
-      @keyframes float {
-        0%, 100% { transform: translateY(0px) rotate(0deg); opacity: 0; }
-        50% { transform: translateY(-20px) rotate(180deg); opacity: 1; }
-      }
-    `}</style>
-  </div>
-);
+const FloatingParticles = ({ count = 15 }) => {
+  const particles = useMemo(
+    () =>
+      Array.from({ length: count }).map(() => ({
+        left: `${Math.random() * 100}%`,
+        top: `${Math.random() * 100}%`,
+        duration: `${3 + Math.random() * 4}s`,
+        delay: `${Math.random() * 2}s`
+      })),
+    [count]
+  );
+
+  return (
+    <div className="absolute inset-0 overflow-hidden pointer-events-none">
+      {particles.map((style, i) => (
+        <div
+          key={i}
+          className="absolute w-2 h-2 bg-gradient-to-br from-blue-400/30 to-purple-400/30 rounded-full"
+          style={{
+            left: style.left,
+            top: style.top,
+            animation: `float ${style.duration} ease-in-out infinite`,
+            animationDelay: style.delay
+          }}
+        />
+      ))}
+      <style jsx>{`
+        @keyframes float {
+          0%, 100% { transform: translateY(0px) rotate(0deg); opacity: 0; }
+          50% { transform: translateY(-20px) rotate(180deg); opacity: 1; }
+        }
+      `}</style>
+    </div>
+  );
+};
 
 // Enhanced Mouse Follower
 const MouseFollower = ({ mousePosition }) => {
@@ -226,7 +239,7 @@ const MouseFollower = ({ mousePosition }) => {
 };
 
 // Main Resume Component
-export default function EnhancedResume() {
+export default function EnhancedResume({ particleCount = 20 }) {
   // State management
   const [expandedSections, setExpandedSections] = useState({
     experience: true,
@@ -547,7 +560,7 @@ export default function EnhancedResume() {
 
       {/* Hero Section - Enhanced */}
       <AnimatedSection id="hero" className="relative min-h-screen flex items-center">
-        <FloatingParticles count={20} />
+        <FloatingParticles count={particleCount} />
         
         <div className="absolute inset-0 bg-gradient-to-br from-slate-900/90 via-blue-900/90 to-indigo-900/90" />
         


### PR DESCRIPTION
## Summary
- Memoize floating particle positions and animation settings to avoid recalculation on each render
- Add `particleCount` prop to `EnhancedResume` so consumers can limit particle count for low-end devices

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4666c1f48327a0201acc363cdaa4